### PR TITLE
Metadata document exploration

### DIFF
--- a/exploration/exploration_metadata_documents.py
+++ b/exploration/exploration_metadata_documents.py
@@ -21,16 +21,18 @@ if __name__ == '__main__':
     doc2pre = pre.prepro_file_load('doc2pre_text', folder_name='full')
     doc2raw = pre.prepro_file_load('doc2raw_text', folder_name='full')
     id2doc = pre.prepro_file_load('id2doc', folder_name='full')
+    doc2author = pre.prepro_file_load('doc2author', folder_name='full')
 
-    id2meta = pre.prepro_file_load('id2category', folder_name='full')
+    id2category = pre.prepro_file_load('id2category', folder_name='full')
     doc2meta = pre.prepro_file_load('doc2category', folder_name='full')
     value = "26. Frederik"
-    # id2meta = pre.prepro_file_load('id2author', folder_name='full')
+    id2author = pre.prepro_file_load('id2author', folder_name='full')
     # doc2meta = pre.prepro_file_load('doc2author', folder_name='full')
     # value = "Villy Dall"
 
-    metaID = find_id_from_value(id2meta, value)
+    metaID = find_id_from_value(id2category, value)
 
+    # get document IDs for documents with the given metadata
     documentIDs = []
     for key, val in doc2meta.items():
         if metaID == val:
@@ -38,16 +40,25 @@ if __name__ == '__main__':
 
     documents = {}
     documentsRaw = {}
+    docAuthors = {}
     docFileNames = {}
+    # get data based on document IDs
     for docID in documentIDs:
-        documents[docID] = doc2pre.get(docID)
-        documentsRaw[docID] = doc2raw.get(docID)
-        docFileNames[docID] = id2doc.get(docID)
+        documents[docID] = doc2pre[docID]
+        documentsRaw[docID] = doc2raw[docID]
+        docAuthors[docID] = doc2author[docID]
+        docFileNames[docID] = id2doc[docID]
 
+    # document list information
     print(f"{len(documents)} documents found\n")
+    print(f"{len(set(docAuthors.values()))} unique authors: ")
+    print(f"{[id2author[id] for id in set(docAuthors.values())]}\n")
+
+    # random examples of documents with ID, author, preprocessed data, and raw data
     print("10 random documents:")
     for count in range(10):
         id = random.choice(documentIDs)
-        print(id)
+        print(f"ID: {id}")
+        print(f"Author: {id2author[docAuthors[id]]}")
         print(documents[id])
         print(documentsRaw[id] + "\n")

--- a/exploration/exploration_metadata_documents.py
+++ b/exploration/exploration_metadata_documents.py
@@ -60,5 +60,6 @@ if __name__ == '__main__':
         id = random.choice(documentIDs)
         print(f"ID: {id}")
         print(f"Author: {id2author[docAuthors[id]]}")
+        print(f"File name: {docFileNames[id]}")
         print(documents[id])
         print(documentsRaw[id] + "\n")

--- a/exploration/exploration_metadata_documents.py
+++ b/exploration/exploration_metadata_documents.py
@@ -1,0 +1,53 @@
+import random
+
+import preprocess.preprocessing as pre
+
+
+def find_id_from_value(dictionary: dict, value: str):
+    id = None
+    for key, val in dictionary.items():
+        if value == val:
+            id = key
+
+    if id is None:
+        print(f"Did not find the value '{value}' in the metadata")
+        exit()
+    else:
+        print(f"Found '{value}' with ID: {id}")
+        return id
+
+
+if __name__ == '__main__':
+    doc2pre = pre.prepro_file_load('doc2pre_text', folder_name='full')
+    doc2raw = pre.prepro_file_load('doc2raw_text', folder_name='full')
+    id2doc = pre.prepro_file_load('id2doc', folder_name='full')
+
+    id2meta = pre.prepro_file_load('id2category', folder_name='full')
+    doc2meta = pre.prepro_file_load('doc2category', folder_name='full')
+    value = "26. Frederik"
+    # id2meta = pre.prepro_file_load('id2author', folder_name='full')
+    # doc2meta = pre.prepro_file_load('doc2author', folder_name='full')
+    # value = "Villy Dall"
+
+    metaID = find_id_from_value(id2meta, value)
+
+    documentIDs = []
+    for key, val in doc2meta.items():
+        if metaID == val:
+            documentIDs.append(key)
+
+    documents = {}
+    documentsRaw = {}
+    docFileNames = {}
+    for docID in documentIDs:
+        documents[docID] = doc2pre.get(docID)
+        documentsRaw[docID] = doc2raw.get(docID)
+        docFileNames[docID] = id2doc.get(docID)
+
+    print(f"{len(documents)} documents found\n")
+    print("10 random documents:")
+    for count in range(10):
+        id = random.choice(documentIDs)
+        print(id)
+        print(documents[id])
+        print(documentsRaw[id] + "\n")


### PR DESCRIPTION
Kode hvor man giver navnet på en specifik metadata, f.eks. kategori "Kultur", og den giver en liste af 10 tilfældige dokumenter der tilhører denne kategori. Information der gives er ID, forfatter, filnavn, prepro tekst og raw tekst. Burde være generel nok til også at virke for author og taxonomy.